### PR TITLE
Issue/18 select friends

### DIFF
--- a/ios-trivia-game.xcodeproj/project.pbxproj
+++ b/ios-trivia-game.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		1A805B6E1DD996F900A70691 /* TriviaQuestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A805B681DD996F900A70691 /* TriviaQuestion.swift */; };
 		1A9553081DDE23EC007BCFCB /* HomeTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A9553071DDE23EC007BCFCB /* HomeTableViewCell.swift */; };
 		4D9054041DE114960029B97E /* SelectFriendsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D9054031DE114960029B97E /* SelectFriendsTableViewCell.swift */; };
+		4D9054061DE26D310029B97E /* Friend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D9054051DE26D310029B97E /* Friend.swift */; };
 		A83ACC821DD2D14B00DAF701 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83ACC811DD2D14B00DAF701 /* AppDelegate.swift */; };
 		A83ACC871DD2D14B00DAF701 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A83ACC851DD2D14B00DAF701 /* Main.storyboard */; };
 		A83ACC891DD2D14B00DAF701 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A83ACC881DD2D14B00DAF701 /* Assets.xcassets */; };
@@ -47,6 +48,7 @@
 		1A9553071DDE23EC007BCFCB /* HomeTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeTableViewCell.swift; sourceTree = "<group>"; };
 		381FCCC7CD6510BD05EB2001 /* Pods-ios-trivia-game.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios-trivia-game.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ios-trivia-game/Pods-ios-trivia-game.debug.xcconfig"; sourceTree = "<group>"; };
 		4D9054031DE114960029B97E /* SelectFriendsTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelectFriendsTableViewCell.swift; sourceTree = "<group>"; };
+		4D9054051DE26D310029B97E /* Friend.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Friend.swift; sourceTree = "<group>"; };
 		A83ACC7E1DD2D14B00DAF701 /* ios-trivia-game.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ios-trivia-game.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A83ACC811DD2D14B00DAF701 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A83ACC861DD2D14B00DAF701 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -211,6 +213,7 @@
 				A8B6EA301DD9A7AA00CB8699 /* User.swift */,
 				1A805B671DD996F900A70691 /* TriviaCategory.swift */,
 				1A805B681DD996F900A70691 /* TriviaQuestion.swift */,
+				4D9054051DE26D310029B97E /* Friend.swift */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -355,6 +358,7 @@
 			files = (
 				A8B32BA91DDC0163003A0B1C /* QuestionViewController.swift in Sources */,
 				A8B32B901DDBE709003A0B1C /* LoginViewController.swift in Sources */,
+				4D9054061DE26D310029B97E /* Friend.swift in Sources */,
 				4D9054041DE114960029B97E /* SelectFriendsTableViewCell.swift in Sources */,
 				A8B32BB31DDC036B003A0B1C /* FinalScoreViewController.swift in Sources */,
 				1A805B6E1DD996F900A70691 /* TriviaQuestion.swift in Sources */,

--- a/ios-trivia-game.xcodeproj/project.pbxproj
+++ b/ios-trivia-game.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		1A805B6D1DD996F900A70691 /* TriviaCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A805B671DD996F900A70691 /* TriviaCategory.swift */; };
 		1A805B6E1DD996F900A70691 /* TriviaQuestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A805B681DD996F900A70691 /* TriviaQuestion.swift */; };
 		1A9553081DDE23EC007BCFCB /* HomeTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A9553071DDE23EC007BCFCB /* HomeTableViewCell.swift */; };
+		4D9054041DE114960029B97E /* SelectFriendsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D9054031DE114960029B97E /* SelectFriendsTableViewCell.swift */; };
 		A83ACC821DD2D14B00DAF701 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A83ACC811DD2D14B00DAF701 /* AppDelegate.swift */; };
 		A83ACC871DD2D14B00DAF701 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A83ACC851DD2D14B00DAF701 /* Main.storyboard */; };
 		A83ACC891DD2D14B00DAF701 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A83ACC881DD2D14B00DAF701 /* Assets.xcassets */; };
@@ -45,6 +46,7 @@
 		1A805B681DD996F900A70691 /* TriviaQuestion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = TriviaQuestion.swift; path = Models/TriviaQuestion.swift; sourceTree = "<group>"; };
 		1A9553071DDE23EC007BCFCB /* HomeTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeTableViewCell.swift; sourceTree = "<group>"; };
 		381FCCC7CD6510BD05EB2001 /* Pods-ios-trivia-game.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios-trivia-game.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ios-trivia-game/Pods-ios-trivia-game.debug.xcconfig"; sourceTree = "<group>"; };
+		4D9054031DE114960029B97E /* SelectFriendsTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelectFriendsTableViewCell.swift; sourceTree = "<group>"; };
 		A83ACC7E1DD2D14B00DAF701 /* ios-trivia-game.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "ios-trivia-game.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A83ACC811DD2D14B00DAF701 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		A83ACC861DD2D14B00DAF701 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -98,6 +100,7 @@
 			isa = PBXGroup;
 			children = (
 				1A9553071DDE23EC007BCFCB /* HomeTableViewCell.swift */,
+				4D9054031DE114960029B97E /* SelectFriendsTableViewCell.swift */,
 			);
 			name = Views;
 			sourceTree = "<group>";
@@ -352,6 +355,7 @@
 			files = (
 				A8B32BA91DDC0163003A0B1C /* QuestionViewController.swift in Sources */,
 				A8B32B901DDBE709003A0B1C /* LoginViewController.swift in Sources */,
+				4D9054041DE114960029B97E /* SelectFriendsTableViewCell.swift in Sources */,
 				A8B32BB31DDC036B003A0B1C /* FinalScoreViewController.swift in Sources */,
 				1A805B6E1DD996F900A70691 /* TriviaQuestion.swift in Sources */,
 				A8B32BA21DDC00C1003A0B1C /* SelectFriendsViewController.swift in Sources */,

--- a/ios-trivia-game/Base.lproj/Main.storyboard
+++ b/ios-trivia-game/Base.lproj/Main.storyboard
@@ -233,9 +233,12 @@
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="KPg-bO-uLg">
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="KPg-bO-uLg">
                                                     <rect key="frame" x="318" y="7" width="51" height="31"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <connections>
+                                                        <action selector="onSwitchChanged:" destination="9Sz-xb-sx7" eventType="valueChanged" id="5MD-Ce-ETE"/>
+                                                    </connections>
                                                 </switch>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="n0g-xt-xvf">
                                                     <rect key="frame" x="8" y="7" width="45" height="45"/>
@@ -245,6 +248,7 @@
                                         </tableViewCellContentView>
                                         <connections>
                                             <outlet property="name" destination="YCF-2C-FYl" id="49X-Ea-bLj"/>
+                                            <outlet property="onSwitch" destination="KPg-bO-uLg" id="Dha-KB-83v"/>
                                             <outlet property="profilePicture" destination="n0g-xt-xvf" id="SFC-V3-SYd"/>
                                         </connections>
                                     </tableViewCell>

--- a/ios-trivia-game/Base.lproj/Main.storyboard
+++ b/ios-trivia-game/Base.lproj/Main.storyboard
@@ -227,20 +227,20 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Full Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YCF-2C-FYl">
-                                                    <rect key="frame" x="61" y="8" width="77" height="21"/>
+                                                    <rect key="frame" x="61" y="8" width="219" height="21"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
-                                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="n0g-xt-xvf">
-                                                    <rect key="frame" x="8" y="0.0" width="45" height="45"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                </imageView>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="KPg-bO-uLg">
                                                     <rect key="frame" x="318" y="7" width="51" height="31"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 </switch>
+                                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="n0g-xt-xvf">
+                                                    <rect key="frame" x="8" y="7" width="45" height="45"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                </imageView>
                                             </subviews>
                                         </tableViewCellContentView>
                                         <connections>

--- a/ios-trivia-game/Base.lproj/Main.storyboard
+++ b/ios-trivia-game/Base.lproj/Main.storyboard
@@ -219,7 +219,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="64" id="9Sz-xb-sx7" customClass="SelectFriendsTableViewCell" customModule="ios_trivia_game" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="com.iostriviagame.selecfriendstableviewcell" rowHeight="64" id="9Sz-xb-sx7" customClass="SelectFriendsTableViewCell" customModule="ios_trivia_game" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="28" width="375" height="64"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="9Sz-xb-sx7" id="5e0-Q8-5WS">
@@ -243,6 +243,10 @@
                                                 </switch>
                                             </subviews>
                                         </tableViewCellContentView>
+                                        <connections>
+                                            <outlet property="name" destination="YCF-2C-FYl" id="49X-Ea-bLj"/>
+                                            <outlet property="profilePicture" destination="n0g-xt-xvf" id="SFC-V3-SYd"/>
+                                        </connections>
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>
@@ -275,6 +279,9 @@
                             </connections>
                         </barButtonItem>
                     </navigationItem>
+                    <connections>
+                        <outlet property="tableView" destination="4Iu-2V-KyZ" id="Sc4-xC-3Am"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="71R-dY-Qol" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/ios-trivia-game/Base.lproj/Main.storyboard
+++ b/ios-trivia-game/Base.lproj/Main.storyboard
@@ -210,9 +210,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <searchBar contentMode="redraw" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="iPN-nu-Uxb">
+                            <searchBar contentMode="redraw" translatesAutoresizingMaskIntoConstraints="NO" id="iPN-nu-Uxb">
                                 <rect key="frame" x="0.0" y="64" width="375" height="44"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                 <textInputTraits key="textInputTraits"/>
                             </searchBar>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="64" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="4Iu-2V-KyZ">
@@ -247,15 +246,22 @@
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Selected Friends:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yeo-Rm-A4k">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Selected Friends:" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yeo-Rm-A4k">
                                 <rect key="frame" x="16" y="124" width="134" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstAttribute="trailing" secondItem="iPN-nu-Uxb" secondAttribute="trailing" id="DW2-cT-S2J"/>
+                            <constraint firstAttribute="trailing" secondItem="yeo-Rm-A4k" secondAttribute="trailing" constant="225" id="LBU-qo-3mw"/>
+                            <constraint firstItem="yeo-Rm-A4k" firstAttribute="top" secondItem="iPN-nu-Uxb" secondAttribute="bottom" constant="16" id="PtK-iZ-Y2g"/>
+                            <constraint firstItem="iPN-nu-Uxb" firstAttribute="top" secondItem="kxs-jd-7ey" secondAttribute="bottom" id="Rel-Wd-iq1"/>
+                            <constraint firstItem="yeo-Rm-A4k" firstAttribute="leading" secondItem="ioa-ST-NVK" secondAttribute="leading" constant="16" id="TAl-ld-29A"/>
+                            <constraint firstItem="iPN-nu-Uxb" firstAttribute="leading" secondItem="ioa-ST-NVK" secondAttribute="leading" id="ljk-b8-J14"/>
+                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="MJN-il-Oi4">
                         <barButtonItem key="leftBarButtonItem" title="Back" id="7oK-RW-j68"/>

--- a/ios-trivia-game/Base.lproj/Main.storyboard
+++ b/ios-trivia-game/Base.lproj/Main.storyboard
@@ -209,6 +209,52 @@
                     <view key="view" contentMode="scaleToFill" id="ioa-ST-NVK">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <searchBar contentMode="redraw" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="iPN-nu-Uxb">
+                                <rect key="frame" x="0.0" y="64" width="375" height="44"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </searchBar>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="64" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="4Iu-2V-KyZ">
+                                <rect key="frame" x="0.0" y="168" width="375" height="499"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="64" id="9Sz-xb-sx7">
+                                        <rect key="frame" x="0.0" y="28" width="375" height="64"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="9Sz-xb-sx7" id="5e0-Q8-5WS">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="63"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Full Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YCF-2C-FYl">
+                                                    <rect key="frame" x="61" y="8" width="77" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="n0g-xt-xvf">
+                                                    <rect key="frame" x="8" y="0.0" width="45" height="45"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                </imageView>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="KPg-bO-uLg">
+                                                    <rect key="frame" x="318" y="7" width="51" height="31"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                </switch>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                </prototypes>
+                            </tableView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Selected Friends:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yeo-Rm-A4k">
+                                <rect key="frame" x="16" y="124" width="134" height="21"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                     </view>
                     <navigationItem key="navigationItem" id="MJN-il-Oi4">
@@ -222,7 +268,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="71R-dY-Qol" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="6193" y="985"/>
+            <point key="canvasLocation" x="6192.8000000000002" y="984.55772113943033"/>
         </scene>
         <!--Game Options-->
         <scene sceneID="WIF-eH-bCI">
@@ -588,7 +634,7 @@
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="5bb-5X-bDg" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="dcG-GP-j2w">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="dcG-GP-j2w">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -606,7 +652,7 @@
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="RHu-CO-bv6" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="dFq-ex-OQM">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="dFq-ex-OQM">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -624,7 +670,7 @@
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Dzo-UG-g8U" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="Pu8-hs-FhN">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="Pu8-hs-FhN">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -642,7 +688,7 @@
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="kGA-Pt-17m" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="wvZ-YW-tHI">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="wvZ-YW-tHI">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>

--- a/ios-trivia-game/Base.lproj/Main.storyboard
+++ b/ios-trivia-game/Base.lproj/Main.storyboard
@@ -255,7 +255,7 @@
                                 </prototypes>
                             </tableView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Selected Friends:" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yeo-Rm-A4k">
-                                <rect key="frame" x="16" y="124" width="134" height="21"/>
+                                <rect key="frame" x="16" y="124" width="343" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -264,7 +264,7 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="iPN-nu-Uxb" secondAttribute="trailing" id="DW2-cT-S2J"/>
-                            <constraint firstAttribute="trailing" secondItem="yeo-Rm-A4k" secondAttribute="trailing" constant="225" id="LBU-qo-3mw"/>
+                            <constraint firstAttribute="trailing" secondItem="yeo-Rm-A4k" secondAttribute="trailing" constant="16" id="LBU-qo-3mw"/>
                             <constraint firstItem="yeo-Rm-A4k" firstAttribute="top" secondItem="iPN-nu-Uxb" secondAttribute="bottom" constant="16" id="PtK-iZ-Y2g"/>
                             <constraint firstItem="iPN-nu-Uxb" firstAttribute="top" secondItem="kxs-jd-7ey" secondAttribute="bottom" id="Rel-Wd-iq1"/>
                             <constraint firstItem="yeo-Rm-A4k" firstAttribute="leading" secondItem="ioa-ST-NVK" secondAttribute="leading" constant="16" id="TAl-ld-29A"/>
@@ -284,6 +284,7 @@
                         </barButtonItem>
                     </navigationItem>
                     <connections>
+                        <outlet property="seletedFriendsLabel" destination="yeo-Rm-A4k" id="e3B-gq-ccJ"/>
                         <outlet property="tableView" destination="4Iu-2V-KyZ" id="Sc4-xC-3Am"/>
                     </connections>
                 </viewController>

--- a/ios-trivia-game/Base.lproj/Main.storyboard
+++ b/ios-trivia-game/Base.lproj/Main.storyboard
@@ -219,7 +219,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="64" id="9Sz-xb-sx7">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="64" id="9Sz-xb-sx7" customClass="SelectFriendsTableViewCell" customModule="ios_trivia_game" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="28" width="375" height="64"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="9Sz-xb-sx7" id="5e0-Q8-5WS">
@@ -264,7 +264,11 @@
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="MJN-il-Oi4">
-                        <barButtonItem key="leftBarButtonItem" title="Back" id="7oK-RW-j68"/>
+                        <barButtonItem key="leftBarButtonItem" title="Back" id="7oK-RW-j68">
+                            <connections>
+                                <action selector="onBackClicked:" destination="ekw-Vi-1cd" id="bRU-FY-WAj"/>
+                            </connections>
+                        </barButtonItem>
                         <barButtonItem key="rightBarButtonItem" title="Game Options" id="xxQ-Jt-ZgS">
                             <connections>
                                 <segue destination="RHu-CO-bv6" kind="presentation" id="i62-4Y-TYv"/>
@@ -378,7 +382,7 @@
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="UpN-wj-CWf" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="xzj-M9-BFF">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="xzj-M9-BFF">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -640,7 +644,7 @@
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="5bb-5X-bDg" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="dcG-GP-j2w">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="dcG-GP-j2w">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -676,7 +680,7 @@
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Dzo-UG-g8U" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="Pu8-hs-FhN">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="Pu8-hs-FhN">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -694,7 +698,7 @@
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="kGA-Pt-17m" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="wvZ-YW-tHI">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="wvZ-YW-tHI">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -792,7 +796,7 @@
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="xWC-Yo-6sB" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="6s3-Jb-LfK">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="6s3-Jb-LfK">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>

--- a/ios-trivia-game/Friend.swift
+++ b/ios-trivia-game/Friend.swift
@@ -20,7 +20,12 @@ class Friend: NSObject {
         let picture = dictionary["picture"] as? NSDictionary
         
         if picture != nil {
-            pictureUrl = picture!["url"] as? String
+            let data = picture!["data"] as? NSDictionary
+            if data != nil {
+                pictureUrl = data!["url"] as? String
+            } else {
+                pictureUrl = ""
+            }
         } else {
             pictureUrl = ""
         }

--- a/ios-trivia-game/Friend.swift
+++ b/ios-trivia-game/Friend.swift
@@ -1,0 +1,39 @@
+//
+//  Friend.swift
+//  ios-trivia-game
+//
+//  Created by Nari Shin on 11/20/16.
+//  Copyright © 2016 Team NZS. All rights reserved.
+//
+
+import Foundation
+
+class Friend: NSObject {
+    var id: String?
+    var name: String?
+    var pictureUrl: String?
+    
+    init(dictionary: NSDictionary) {
+        self.id = dictionary["id"] as? String
+        self.name = dictionary["name"] as? String
+        
+        let picture = dictionary["picture"] as? NSDictionary
+        
+        if picture != nil {
+            pictureUrl = picture!["url"] as? String
+        } else {
+            pictureUrl = ""
+        }
+    }
+    
+    class func FriendsWithArray(dictionaries: [NSDictionary]) -> [Friend] {
+        var friends = [Friend]()
+        
+        for dictionary in dictionaries {
+            let friend = Friend(dictionary: dictionary)
+            friends.append(friend)
+        }
+        
+        return friends
+    }
+}

--- a/ios-trivia-game/Friend.swift
+++ b/ios-trivia-game/Friend.swift
@@ -12,6 +12,7 @@ class Friend: NSObject {
     var id: String?
     var name: String?
     var pictureUrl: String?
+    var isSelected: Bool?
     
     init(dictionary: NSDictionary) {
         self.id = dictionary["id"] as? String
@@ -29,6 +30,8 @@ class Friend: NSObject {
         } else {
             pictureUrl = ""
         }
+        
+        isSelected = false
     }
     
     class func FriendsWithArray(dictionaries: [NSDictionary]) -> [Friend] {

--- a/ios-trivia-game/SelectFriendsTableViewCell.swift
+++ b/ios-trivia-game/SelectFriendsTableViewCell.swift
@@ -10,6 +10,18 @@ import UIKit
 
 class SelectFriendsTableViewCell: UITableViewCell {
 
+    @IBOutlet weak var profilePicture: UIImageView!
+    @IBOutlet weak var name: UILabel!
+    
+    var friend: Friend! {
+        didSet {
+            name.text = friend.name
+            if let imageUrl = friend.pictureUrl {
+                profilePicture.setImageWith(URL(string: imageUrl)!)
+            }
+        }
+    }
+    
     override func awakeFromNib() {
         super.awakeFromNib()
         // Initialization code

--- a/ios-trivia-game/SelectFriendsTableViewCell.swift
+++ b/ios-trivia-game/SelectFriendsTableViewCell.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 @objc protocol SelectFriendsTableViewCellDelegate {
-    @objc optional func selectFriendsTableViewCell(switchCell: SelectFriendsTableViewCell, didChangeValue value: Bool)
+    @objc optional func selectFriendsTableViewCell(selectFriendsTableViewCell: SelectFriendsTableViewCell, didChangeValue value: Bool)
 }
 
 class SelectFriendsTableViewCell: UITableViewCell {
@@ -43,6 +43,6 @@ class SelectFriendsTableViewCell: UITableViewCell {
     }
 
     @IBAction func onSwitchChanged(_ sender: Any) {
-        delegate?.selectFriendsTableViewCell?(switchCell: self, didChangeValue: onSwitch.isOn)
+        delegate?.selectFriendsTableViewCell?(selectFriendsTableViewCell: self, didChangeValue: onSwitch.isOn)
     }
 }

--- a/ios-trivia-game/SelectFriendsTableViewCell.swift
+++ b/ios-trivia-game/SelectFriendsTableViewCell.swift
@@ -1,0 +1,24 @@
+//
+//  SelectFriendsTableViewCell.swift
+//  ios-trivia-game
+//
+//  Created by Nari Shin on 11/19/16.
+//  Copyright © 2016 Team NZS. All rights reserved.
+//
+
+import UIKit
+
+class SelectFriendsTableViewCell: UITableViewCell {
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        // Initialization code
+    }
+
+    override func setSelected(_ selected: Bool, animated: Bool) {
+        super.setSelected(selected, animated: animated)
+
+        // Configure the view for the selected state
+    }
+
+}

--- a/ios-trivia-game/SelectFriendsTableViewCell.swift
+++ b/ios-trivia-game/SelectFriendsTableViewCell.swift
@@ -8,10 +8,17 @@
 
 import UIKit
 
+@objc protocol SelectFriendsTableViewCellDelegate {
+    @objc optional func selectFriendsTableViewCell(switchCell: SelectFriendsTableViewCell, didChangeValue value: Bool)
+}
+
 class SelectFriendsTableViewCell: UITableViewCell {
 
     @IBOutlet weak var profilePicture: UIImageView!
     @IBOutlet weak var name: UILabel!
+    @IBOutlet weak var onSwitch: UISwitch!
+    
+    weak var delegate: SelectFriendsTableViewCellDelegate?
     
     var friend: Friend! {
         didSet {
@@ -25,6 +32,8 @@ class SelectFriendsTableViewCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         // Initialization code
+        
+        onSwitch.addTarget(self, action: #selector(SelectFriendsTableViewCell.onSwitchChanged), for: UIControlEvents.valueChanged)
     }
 
     override func setSelected(_ selected: Bool, animated: Bool) {
@@ -33,4 +42,7 @@ class SelectFriendsTableViewCell: UITableViewCell {
         // Configure the view for the selected state
     }
 
+    @IBAction func onSwitchChanged(_ sender: Any) {
+        delegate?.selectFriendsTableViewCell?(switchCell: self, didChangeValue: onSwitch.isOn)
+    }
 }

--- a/ios-trivia-game/ViewControllers/SelectFriendsViewController.swift
+++ b/ios-trivia-game/ViewControllers/SelectFriendsViewController.swift
@@ -17,6 +17,7 @@ class SelectFriendsViewController: UIViewController {
     var numOfPlayers: Int?
     var isPublic: Bool?
     var friends = [Friend]()
+    var selectedFriends = [Bool]()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -24,8 +25,6 @@ class SelectFriendsViewController: UIViewController {
         // Do any additional setup after loading the view.
         setupTableView()
         loadFriendsList()
-        
-        
     }
 
     override func didReceiveMemoryWarning() {
@@ -84,7 +83,15 @@ extension SelectFriendsViewController: UITableViewDataSource, UITableViewDelegat
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "com.iostriviagame.selecfriendstableviewcell", for: indexPath) as! SelectFriendsTableViewCell
         cell.friend = self.friends[indexPath.row]
+        cell.delegate = self
         return cell
-        
+    }
+}
+
+extension SelectFriendsViewController: SelectFriendsTableViewCellDelegate {
+    
+    func selectFriendsTableViewCell(selectFriendsTableViewCell: SelectFriendsTableViewCell, didChangeValue value: Bool) {
+        let indexPath = tableView.indexPath(for: selectFriendsTableViewCell)!
+        self.friends[indexPath.row].isSelected = value
     }
 }

--- a/ios-trivia-game/ViewControllers/SelectFriendsViewController.swift
+++ b/ios-trivia-game/ViewControllers/SelectFriendsViewController.swift
@@ -58,7 +58,7 @@ class SelectFriendsViewController: UIViewController {
             let dictionaries = data["data"] as! [NSDictionary]
             self.friends = Friend.FriendsWithArray(dictionaries: dictionaries)
             for friend in self.friends {
-                print("name : \(friend.name)")
+                print("url : \(friend.pictureUrl)")
             }
             self.tableView.reloadData()
         })

--- a/ios-trivia-game/ViewControllers/SelectFriendsViewController.swift
+++ b/ios-trivia-game/ViewControllers/SelectFriendsViewController.swift
@@ -7,8 +7,11 @@
 //
 
 import UIKit
+import FacebookCore
 
 class SelectFriendsViewController: UIViewController {
+    
+    
     
     var numOfPlayers: Int?
     var isPublic: Bool?
@@ -17,6 +20,8 @@ class SelectFriendsViewController: UIViewController {
         super.viewDidLoad()
 
         // Do any additional setup after loading the view.
+        
+        
     }
 
     override func didReceiveMemoryWarning() {
@@ -24,6 +29,10 @@ class SelectFriendsViewController: UIViewController {
         // Dispose of any resources that can be recreated.
     }
     
+    @IBAction func onBackClicked(_ sender: Any) {
+        dismiss(animated: true, completion: nil)
+        _ = self.navigationController?.popViewController(animated: true)
+    }
 
     /*
     // MARK: - Navigation

--- a/ios-trivia-game/ViewControllers/SelectFriendsViewController.swift
+++ b/ios-trivia-game/ViewControllers/SelectFriendsViewController.swift
@@ -50,6 +50,9 @@ class SelectFriendsViewController: UIViewController {
 //                /* Handle response */
 //            }
             print("result : \(result)")
+            let dictionaries = result as! [NSDictionary]
+            
+            let frields = Friend.FriendsWithArray(dictionaries: dictionaries)
         })
     }
 

--- a/ios-trivia-game/ViewControllers/SelectFriendsViewController.swift
+++ b/ios-trivia-game/ViewControllers/SelectFriendsViewController.swift
@@ -12,15 +12,19 @@ import FBSDKLoginKit
 
 class SelectFriendsViewController: UIViewController {
     
+    @IBOutlet weak var tableView: UITableView!
+    
     var numOfPlayers: Int?
     var isPublic: Bool?
+    var friends = [Friend]()
     
     override func viewDidLoad() {
         super.viewDidLoad()
 
         // Do any additional setup after loading the view.
-        
+        setupTableView()
         loadFriendsList()
+        
         
     }
 
@@ -34,6 +38,13 @@ class SelectFriendsViewController: UIViewController {
         _ = self.navigationController?.popViewController(animated: true)
     }
     
+    func setupTableView() {
+        tableView.delegate = self
+        tableView.dataSource = self
+        tableView.estimatedRowHeight = 100
+        tableView.rowHeight = UITableViewAutomaticDimension
+    }
+    
     func loadFriendsList() {
         let params = ["fields": "id, first_name, last_name, middle_name, name, email, picture"]
         let request = FBSDKGraphRequest(graphPath: "me/taggable_friends", parameters: params)
@@ -45,10 +56,11 @@ class SelectFriendsViewController: UIViewController {
             print("result : \(result)")
             let data = result as! NSDictionary
             let dictionaries = data["data"] as! [NSDictionary]
-            let friends = Friend.FriendsWithArray(dictionaries: dictionaries)
-            for friend in friends {
+            self.friends = Friend.FriendsWithArray(dictionaries: dictionaries)
+            for friend in self.friends {
                 print("name : \(friend.name)")
             }
+            self.tableView.reloadData()
         })
     }
 
@@ -61,4 +73,18 @@ class SelectFriendsViewController: UIViewController {
         // Pass the selected object to the new view controller.
     }
     */
+}
+
+extension SelectFriendsViewController: UITableViewDataSource, UITableViewDelegate {
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return self.friends.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "com.iostriviagame.selecfriendstableviewcell", for: indexPath) as! SelectFriendsTableViewCell
+        cell.friend = self.friends[indexPath.row]
+        return cell
+        
+    }
 }

--- a/ios-trivia-game/ViewControllers/SelectFriendsViewController.swift
+++ b/ios-trivia-game/ViewControllers/SelectFriendsViewController.swift
@@ -13,6 +13,7 @@ import FBSDKLoginKit
 class SelectFriendsViewController: UIViewController {
     
     @IBOutlet weak var tableView: UITableView!
+    @IBOutlet weak var seletedFriendsLabel: UILabel!
     
     var numOfPlayers: Int?
     var isPublic: Bool?
@@ -93,5 +94,16 @@ extension SelectFriendsViewController: SelectFriendsTableViewCellDelegate {
     func selectFriendsTableViewCell(selectFriendsTableViewCell: SelectFriendsTableViewCell, didChangeValue value: Bool) {
         let indexPath = tableView.indexPath(for: selectFriendsTableViewCell)!
         self.friends[indexPath.row].isSelected = value
+        
+        updateSelectedFriendsLabel(isSelected: value, name: friends[indexPath.row].name!)
+    }
+    
+    func updateSelectedFriendsLabel(isSelected: Bool, name: String) {
+        
+        if isSelected {
+            self.seletedFriendsLabel.text = seletedFriendsLabel.text! + " \(name)"
+        }
+        
+        // TODO: Should handle the removing case.
     }
 }

--- a/ios-trivia-game/ViewControllers/SelectFriendsViewController.swift
+++ b/ios-trivia-game/ViewControllers/SelectFriendsViewController.swift
@@ -12,48 +12,16 @@ import FBSDKLoginKit
 
 class SelectFriendsViewController: UIViewController {
     
-    
-    
     var numOfPlayers: Int?
     var isPublic: Bool?
-
-//    struct MyProfileRequest: GraphRequestProtocol {
-//        struct Response: GraphResponseProtocol {
-//            init(rawResponse: Any?) {
-//                // Decode JSON from rawResponse into other properties here.
-//            }
-//        }
-//        
-//        var graphPath = "/me/friends"
-//        var parameters: [String : Any]? = ["fields": "id, name"]
-//        var accessToken = AccessToken.current
-//        var httpMethod: GraphRequestHTTPMethod = .GET
-//        var apiVersion: GraphAPIVersion = .defaultVersion
-//    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
 
         // Do any additional setup after loading the view.
         
-        print("access token : \(AccessToken.current)")
+        loadFriendsList()
         
-        
-        let params = ["fields": "id, first_name, last_name, middle_name, name, email, picture"]
-        let request = FBSDKGraphRequest(graphPath: "me/taggable_friends", parameters: params)
-        request?.start(completionHandler: { (connection: FBSDKGraphRequestConnection?, result: Any?, error: Error?) in
-            if error != nil {
-                let errorMessage = error?.localizedDescription
-                print("error: \(errorMessage)")
-            }
-//            else if result.isKindOfClass(NSDictionary){
-//                /* Handle response */
-//            }
-            print("result : \(result)")
-            let dictionaries = result as! [NSDictionary]
-            
-            let frields = Friend.FriendsWithArray(dictionaries: dictionaries)
-        })
     }
 
     override func didReceiveMemoryWarning() {
@@ -64,6 +32,24 @@ class SelectFriendsViewController: UIViewController {
     @IBAction func onBackClicked(_ sender: Any) {
         dismiss(animated: true, completion: nil)
         _ = self.navigationController?.popViewController(animated: true)
+    }
+    
+    func loadFriendsList() {
+        let params = ["fields": "id, first_name, last_name, middle_name, name, email, picture"]
+        let request = FBSDKGraphRequest(graphPath: "me/taggable_friends", parameters: params)
+        request?.start(completionHandler: { (connection: FBSDKGraphRequestConnection?, result: Any?, error: Error?) in
+            if error != nil {
+                let errorMessage = error?.localizedDescription
+                print("error: \(errorMessage)")
+            }
+            print("result : \(result)")
+            let data = result as! NSDictionary
+            let dictionaries = data["data"] as! [NSDictionary]
+            let friends = Friend.FriendsWithArray(dictionaries: dictionaries)
+            for friend in friends {
+                print("name : \(friend.name)")
+            }
+        })
     }
 
     /*

--- a/ios-trivia-game/ViewControllers/SelectFriendsViewController.swift
+++ b/ios-trivia-game/ViewControllers/SelectFriendsViewController.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import FacebookCore
+import FBSDKLoginKit
 
 class SelectFriendsViewController: UIViewController {
     
@@ -16,12 +17,40 @@ class SelectFriendsViewController: UIViewController {
     var numOfPlayers: Int?
     var isPublic: Bool?
 
+//    struct MyProfileRequest: GraphRequestProtocol {
+//        struct Response: GraphResponseProtocol {
+//            init(rawResponse: Any?) {
+//                // Decode JSON from rawResponse into other properties here.
+//            }
+//        }
+//        
+//        var graphPath = "/me/friends"
+//        var parameters: [String : Any]? = ["fields": "id, name"]
+//        var accessToken = AccessToken.current
+//        var httpMethod: GraphRequestHTTPMethod = .GET
+//        var apiVersion: GraphAPIVersion = .defaultVersion
+//    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
         // Do any additional setup after loading the view.
         
+        print("access token : \(AccessToken.current)")
         
+        
+        let params = ["fields": "id, first_name, last_name, middle_name, name, email, picture"]
+        let request = FBSDKGraphRequest(graphPath: "me/taggable_friends", parameters: params)
+        request?.start(completionHandler: { (connection: FBSDKGraphRequestConnection?, result: Any?, error: Error?) in
+            if error != nil {
+                let errorMessage = error?.localizedDescription
+                print("error: \(errorMessage)")
+            }
+//            else if result.isKindOfClass(NSDictionary){
+//                /* Handle response */
+//            }
+            print("result : \(result)")
+        })
     }
 
     override func didReceiveMemoryWarning() {
@@ -43,5 +72,4 @@ class SelectFriendsViewController: UIViewController {
         // Pass the selected object to the new view controller.
     }
     */
-
 }


### PR DESCRIPTION
This PR enables reading friends list from user's FB account, and select them to start game. It took a while to figure out how to read friends list, because a lot of ios+fb code were outdated. 

Currently, it only works for the happy path, so search bar doesn't do anything, and we're missing a case where unselect friends. I'll fix those in a separate PR when I have time.

![issue18](https://cloud.githubusercontent.com/assets/2025025/20468651/86c31c32-af4d-11e6-92ae-6143d50d57c1.gif)

One more thing! For some reason, the FB session is not persisted, so I have to logout and login again to test. Based on my research, that can be happen when the `Keychain Sharing` is off, but it seems like it is enabled in our project. Also, I noticed that the game room view doesn't load data sometimes. Let me know if you guys see the same thing!
