### PR TITLE
Issue/api for creating game

### DIFF
--- a/ios-trivia-game/API/FirebaseClient.swift
+++ b/ios-trivia-game/API/FirebaseClient.swift
@@ -133,4 +133,11 @@ class FirebaseClient {
         answer.timestamp = String(describing: NSDate())
         newAnswer.setValue(answer.getJson(), withCompletionBlock: { (error, ref) in complete(error, ref) })
     }
+    
+    // Creates a game
+    func createGame(gameRoom: NSDictionary, complete: @escaping (Error?, FIRDatabaseReference) -> Void) {
+        let path = "\(Constants.GAME_ROOM_TABLE_NAME)"
+        let newGameRoom = ref.child(path).childByAutoId()
+        newGameRoom.setValue(gameRoom, withCompletionBlock: { (error, ref) in complete(error, ref)})
+    }
 }

--- a/ios-trivia-game/Base.lproj/Main.storyboard
+++ b/ios-trivia-game/Base.lproj/Main.storyboard
@@ -338,7 +338,7 @@
                         </barButtonItem>
                         <barButtonItem key="rightBarButtonItem" title="Start Game" id="UPb-KT-vZq">
                             <connections>
-                                <segue destination="Dzo-UG-g8U" kind="presentation" id="uZo-eF-jm3"/>
+                                <action selector="onStartGameClicked:" destination="i5F-5m-G0r" id="OZ1-l3-TMQ"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>

--- a/ios-trivia-game/Base.lproj/Main.storyboard
+++ b/ios-trivia-game/Base.lproj/Main.storyboard
@@ -280,7 +280,7 @@
                         </barButtonItem>
                         <barButtonItem key="rightBarButtonItem" title="Game Options" id="xxQ-Jt-ZgS">
                             <connections>
-                                <segue destination="RHu-CO-bv6" kind="presentation" id="i62-4Y-TYv"/>
+                                <action selector="onGameOptionsClicked:" destination="ekw-Vi-1cd" id="EB3-bz-3fn"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -808,7 +808,7 @@
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="kGA-Pt-17m" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="wvZ-YW-tHI">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="wvZ-YW-tHI">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -844,7 +844,7 @@
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="OYM-1H-SDT" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="ECi-Sp-Mrl">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="ECi-Sp-Mrl">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -906,7 +906,7 @@
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="xWC-Yo-6sB" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="6s3-Jb-LfK">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="6s3-Jb-LfK">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>

--- a/ios-trivia-game/Constants.swift
+++ b/ios-trivia-game/Constants.swift
@@ -20,8 +20,11 @@ class Constants {
     static let LOGIN_MODAL_SEGUE = "com.iostriviagame.loginSegue"
     static let ANSWER_TO_RESULTS_SEGUE = "com.iostriviagame.answertoresultssegue"
     
+    
     // UI Identifiers
     static let MAIN_TAB_VIEW_CONTROLLER = "com.iostriviagame.maintabviewcontroller"
     static let ANSWER_TABLE_VIEW_CELL = "com.iostriviagame.answertableviewcell"
+    static let SELECT_FRIENDS_VIEW_CONTROLLER = "com.iostriviagame.selectfriendsviewcontroller"
+    static let GAME_OPTIONS_VIEW_CONTROLLER = "com.iostriviagame.gameoptionsviewcontroller"
 }
 

--- a/ios-trivia-game/ViewControllers/CreateGameViewController.swift
+++ b/ios-trivia-game/ViewControllers/CreateGameViewController.swift
@@ -48,7 +48,7 @@ class CreateGameViewController: UIViewController {
     
     @IBAction func selectFriendsClicked(_ sender: Any) {
         let storyboard = UIStoryboard(name: "Main", bundle: nil)
-        let selectFriendsViewController = storyboard.instantiateViewController(withIdentifier: "com.iostriviagame.selectfriendsviewcontroller") as! SelectFriendsViewController
+        let selectFriendsViewController = storyboard.instantiateViewController(withIdentifier: Constants.SELECT_FRIENDS_VIEW_CONTROLLER) as! SelectFriendsViewController
         selectFriendsViewController.numOfPlayers = self.numOfPlayers
         selectFriendsViewController.isPublic = self.isPublic
         self.navigationController?.pushViewController(selectFriendsViewController, animated: true)

--- a/ios-trivia-game/ViewControllers/GameOptionsViewController.swift
+++ b/ios-trivia-game/ViewControllers/GameOptionsViewController.swift
@@ -75,6 +75,18 @@ class GameOptionsViewController: UIViewController {
         _ = self.navigationController?.popViewController(animated: true)
     }
 
+    // Make an api call to create a game room, and then go to CountdownTimerViewController if it succeeds.
+    @IBAction func onStartGameClicked(_ sender: Any) {
+        print("game started clicked")
+        var newGame = ["max_num_of_questions" : numOfQuestions ?? 0,
+                   "current_question" : 0,
+                   "is_public" : isPublic ?? true,
+                   "max_num_people" : numOfPlayers ?? 5,
+                   "name" : "test",
+                   "state" : 0] as [String: Any]
+        
+        FirebaseClient.instance.createGame(gameRoom: newGame as NSDictionary, complete: {_,_ in })
+    }
     /*
     // MARK: - Navigation
 

--- a/ios-trivia-game/ViewControllers/GameOptionsViewController.swift
+++ b/ios-trivia-game/ViewControllers/GameOptionsViewController.swift
@@ -13,6 +13,12 @@ class GameOptionsViewController: UIViewController {
     @IBOutlet weak var categoryPicker: UIPickerView!
     @IBOutlet weak var numOfQuestionsPicker: UIPickerView!
     
+    // API Data
+    var numOfPlayers: Int?
+    var isPublic: Bool?
+    var selectedFriends = Set<String>()
+    
+    // UI Data
     var categoryPickerData: [String] = [String]()
     var numOfQuestionsPickerData: [String] = [String]()
     

--- a/ios-trivia-game/ViewControllers/SelectFriendsViewController.swift
+++ b/ios-trivia-game/ViewControllers/SelectFriendsViewController.swift
@@ -18,7 +18,8 @@ class SelectFriendsViewController: UIViewController {
     var numOfPlayers: Int?
     var isPublic: Bool?
     var friends = [Friend]()
-    var selectedFriends = [Bool]()
+    var currentSelectedCount:Int = 1
+    var isFromUserEvent:Bool = true
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -80,6 +81,7 @@ extension SelectFriendsViewController: UITableViewDataSource, UITableViewDelegat
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "com.iostriviagame.selecfriendstableviewcell", for: indexPath) as! SelectFriendsTableViewCell
         cell.friend = self.friends[indexPath.row]
+        cell.onSwitch.isOn = self.friends[indexPath.row].isSelected ?? false
         cell.delegate = self
         return cell
     }
@@ -89,9 +91,32 @@ extension SelectFriendsViewController: SelectFriendsTableViewCellDelegate {
     
     func selectFriendsTableViewCell(selectFriendsTableViewCell: SelectFriendsTableViewCell, didChangeValue value: Bool) {
         let indexPath = tableView.indexPath(for: selectFriendsTableViewCell)!
-        self.friends[indexPath.row].isSelected = value
         
-        updateSelectedFriendsLabel(isSelected: value, name: friends[indexPath.row].name!)
+        if value && currentSelectedCount >= numOfPlayers! {
+            let alertController = UIAlertController(title: "Warning", message:
+                "You can invite maximum \(numOfPlayers!-1) people", preferredStyle: UIAlertControllerStyle.alert)
+            alertController.addAction(UIAlertAction(title: "Dismiss", style: UIAlertActionStyle.default,handler: nil))
+            self.present(alertController, animated: true, completion: nil)
+            
+            if isFromUserEvent {
+                selectFriendsTableViewCell.onSwitch.isOn = false
+                isFromUserEvent = false
+            }
+        } else {
+        
+            if isFromUserEvent {
+                self.friends[indexPath.row].isSelected = value
+                if value {
+                    currentSelectedCount += 1
+                } else {
+                    currentSelectedCount -= 1
+                }
+        
+                updateSelectedFriendsLabel(isSelected: value, name: friends[indexPath.row].name!)
+            } else {
+                isFromUserEvent = true
+            }
+        }
     }
     
     func updateSelectedFriendsLabel(isSelected: Bool, name: String) {

--- a/ios-trivia-game/ViewControllers/SelectFriendsViewController.swift
+++ b/ios-trivia-game/ViewControllers/SelectFriendsViewController.swift
@@ -20,6 +20,7 @@ class SelectFriendsViewController: UIViewController {
     var friends = [Friend]()
     var currentSelectedCount:Int = 1
     var isFromUserEvent:Bool = true
+    var selectedFriends = Set<String>()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -61,6 +62,14 @@ class SelectFriendsViewController: UIViewController {
         })
     }
 
+    @IBAction func onGameOptionsClicked(_ sender: Any) {
+        let storyboard = UIStoryboard(name: "Main", bundle: nil)
+        let gameOptionsViewController = storyboard.instantiateViewController(withIdentifier: Constants.GAME_OPTIONS_VIEW_CONTROLLER) as! GameOptionsViewController
+        gameOptionsViewController.numOfPlayers = self.numOfPlayers
+        gameOptionsViewController.isPublic = self.isPublic
+        gameOptionsViewController.selectedFriends = self.selectedFriends
+        self.navigationController?.pushViewController(gameOptionsViewController, animated: true)
+    }
     /*
     // MARK: - Navigation
 
@@ -108,8 +117,10 @@ extension SelectFriendsViewController: SelectFriendsTableViewCellDelegate {
                 self.friends[indexPath.row].isSelected = value
                 if value {
                     currentSelectedCount += 1
+                    selectedFriends.insert(selectFriendsTableViewCell.friend.id!)
                 } else {
                     currentSelectedCount -= 1
+                    selectedFriends.remove(selectFriendsTableViewCell.friend.id!)
                 }
         
                 updateSelectedFriendsLabel(isSelected: value, name: friends[indexPath.row].name!)


### PR DESCRIPTION
This PR enables the API call to Firebase to create a game in `game_room` table like below:
<img width="335" alt="screen shot 2016-11-26 at 9 28 12 pm" src="https://cloud.githubusercontent.com/assets/2025025/20645842/941e00fa-b41f-11e6-9a1a-7fe2c5d042be.png">

As you can see, the `key` value of `game_room` hash is auto generated, and I didn't set `id` in the object, because I think we should generate it automatically from the Firebase instance, not by hard-coding it. If you guys agree with that, I'll put the auto-generated `id` in a separate PR.

Newly created game room looks like this:

<img width="376" alt="screen shot 2016-11-26 at 9 33 14 pm" src="https://cloud.githubusercontent.com/assets/2025025/20645870/137ce62c-b420-11e6-87b1-ebfaba55d96a.png">

Let me know if you guys notice anything!