### PR TITLE
Issue/59 implement adding invites to invite table selectfriends

### DIFF
--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -3370,7 +3370,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0810;
 			};
 			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -4016,7 +4016,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 0398F51AC352024D0A6FCFD8F8977058 /* Alamofire.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
@@ -4047,7 +4047,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E5AEF550FFBDF376D7ACB3677B94AA37 /* SwiftIconFont.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
@@ -4077,7 +4077,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 2EDA40549CAE40F45CC157C2CE6143B8 /* FacebookLogin.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
@@ -4108,7 +4108,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = EBF58031A90D9FD95CFB49374743B9B4 /* Bolts.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
@@ -4138,7 +4138,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 0938D594261DFB4EC68F769F5D2E16A8 /* AFNetworking.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
@@ -4168,7 +4168,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4AE6E5334684675906E1400858FC635D /* MBProgressHUD.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
@@ -4198,7 +4198,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = EBF58031A90D9FD95CFB49374743B9B4 /* Bolts.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
@@ -4228,7 +4228,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 891673E8EAB79AF5EA74D4F99C35C703 /* FBSDKCoreKit.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
@@ -4268,13 +4268,17 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = YES;
 				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"POD_CONFIGURATION_RELEASE=1",
 					"$(inherited)",
@@ -4287,6 +4291,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				STRIP_INSTALLED_PRODUCT = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SYMROOT = "${SRCROOT}/../build";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -4296,7 +4301,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 2EDA40549CAE40F45CC157C2CE6143B8 /* FacebookLogin.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
@@ -4326,7 +4331,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = AC2EDA933F6AAD1889E566EC9D7A2EFF /* FBSDKLoginKit.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
@@ -4356,7 +4361,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 92AA160184ACC3BDEF5069F0C170D822 /* Pods-ios-trivia-game.release.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
@@ -4390,7 +4396,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E5AEF550FFBDF376D7ACB3677B94AA37 /* SwiftIconFont.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
@@ -4421,7 +4427,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5554C6BC068AC8C628B562252416CF32 /* FBSDKShareKit.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
@@ -4451,7 +4457,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 0398F51AC352024D0A6FCFD8F8977058 /* Alamofire.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
@@ -4481,7 +4487,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4781935212CA4250AF0E5A394359BD58 /* FacebookCore.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
@@ -4512,7 +4518,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 8FC803722462950F248C9458A2AB096F /* BDBOAuth1Manager.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
@@ -4542,7 +4548,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = AC2EDA933F6AAD1889E566EC9D7A2EFF /* FBSDKLoginKit.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
@@ -4572,7 +4578,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 2FC17BBF72C52EDCDDDE4F7FA5F0C636 /* GoogleToolboxForMac.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
@@ -4602,7 +4608,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A712312B7B86930D6D24CB3C00D2ACFD /* FacebookShare.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
@@ -4632,7 +4638,8 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F6C964A1EC24FAE155373E0943BD0B18 /* Pods-ios-trivia-game.debug.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
@@ -4667,7 +4674,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4AE6E5334684675906E1400858FC635D /* MBProgressHUD.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
@@ -4697,7 +4704,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5554C6BC068AC8C628B562252416CF32 /* FBSDKShareKit.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
@@ -4727,7 +4734,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3A7A63EA154BFCB3748816629FC9B264 /* GTMSessionFetcher.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
@@ -4757,7 +4764,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 2FC17BBF72C52EDCDDDE4F7FA5F0C636 /* GoogleToolboxForMac.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
@@ -4787,7 +4794,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 0938D594261DFB4EC68F769F5D2E16A8 /* AFNetworking.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
@@ -4827,14 +4834,18 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"POD_CONFIGURATION_DEBUG=1",
@@ -4859,7 +4870,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 891673E8EAB79AF5EA74D4F99C35C703 /* FBSDKCoreKit.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
@@ -4889,7 +4900,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 3A7A63EA154BFCB3748816629FC9B264 /* GTMSessionFetcher.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
@@ -4919,7 +4930,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 8FC803722462950F248C9458A2AB096F /* BDBOAuth1Manager.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
@@ -4949,7 +4960,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4781935212CA4250AF0E5A394359BD58 /* FacebookCore.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
@@ -4979,7 +4990,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A712312B7B86930D6D24CB3C00D2ACFD /* FacebookShare.xcconfig */;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;

--- a/ios-trivia-game.xcodeproj/project.pbxproj
+++ b/ios-trivia-game.xcodeproj/project.pbxproj
@@ -186,8 +186,8 @@
 		A8B32B8E1DDBE6E7003A0B1C /* ViewControllers */ = {
 			isa = PBXGroup;
 			children = (
-				B2AFE4571DEC20B700999BD1 /* Invite */,
 				A8B32BB41DDC0379003A0B1C /* HomeViewController.swift */,
+				B2AFE4571DEC20B700999BD1 /* Invite */,
 				A8B32BA71DDC0129003A0B1C /* Game */,
 				A8B32B9E1DDC006F003A0B1C /* CreateGame */,
 				A8B32B9D1DDC0058003A0B1C /* Profile */,

--- a/ios-trivia-game.xcodeproj/project.pbxproj
+++ b/ios-trivia-game.xcodeproj/project.pbxproj
@@ -32,13 +32,13 @@
 		A8E541571DD9A9EB002D6AA4 /* JServiceClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E1ED9E1DD5A03D00460AA5 /* JServiceClient.swift */; };
 		A8E541581DD9A9EB002D6AA4 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A36860A1DD83CCC00CBEB41 /* Constants.swift */; };
 		B2009CED1DE5B70500CF0FB1 /* ScoredAnswer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2009CEC1DE5B70500CF0FB1 /* ScoredAnswer.swift */; };
+		B236DB1B1DEEC65A0057D263 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B236DB191DEEC65A0057D263 /* Main.storyboard */; };
 		B29417051DE29A1300153E36 /* UserInGame.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29417041DE29A1300153E36 /* UserInGame.swift */; };
 		B29417071DE29E3A00153E36 /* FirebaseClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29417061DE29E3A00153E36 /* FirebaseClient.swift */; };
 		B294170A1DE2AD8100153E36 /* SelectFriendsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29417081DE2AD8100153E36 /* SelectFriendsTableViewCell.swift */; };
 		B294170B1DE2AD8100153E36 /* HomeTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29417091DE2AD8100153E36 /* HomeTableViewCell.swift */; };
 		B29417101DE2DF8A00153E36 /* AnswerTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B294170F1DE2DF8A00153E36 /* AnswerTableViewCell.swift */; };
 		B29BE1FD1DD7BB6B000DD684 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29BE1FC1DD7BB6B000DD684 /* Logger.swift */; };
-		B29E8C761DF0220600A1D48A /* FacebookClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29E8C751DF0220600A1D48A /* FacebookClient.swift */; };
 		B2AFE4591DEC20CB00999BD1 /* InviteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2AFE4581DEC20CB00999BD1 /* InviteViewController.swift */; };
 		B2AFE45B1DEC292C00999BD1 /* Invite.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2AFE45A1DEC292C00999BD1 /* Invite.swift */; };
 		B2AFE45D1DEC2C1700999BD1 /* InviteTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2AFE45C1DEC2C1700999BD1 /* InviteTableViewCell.swift */; };
@@ -47,7 +47,7 @@
 		B2DE69C71DEB79070038B860 /* FinalScore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2DE69C61DEB79070038B860 /* FinalScore.swift */; };
 		B2DE69C91DEB7E3E0038B860 /* FinalScoreTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2DE69C81DEB7E3E0038B860 /* FinalScoreTableViewCell.swift */; };
 		B2E11B1A1DE3F83C0008F8E0 /* Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E11B191DE3F83C0008F8E0 /* Utilities.swift */; };
-		B2E6D3901DF2957B001ABF12 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B2E6D38E1DF2957B001ABF12 /* Main.storyboard */; };
+		B2EEF4F21DF2E23700BCA44D /* FacebookClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2EEF4F11DF2E23700BCA44D /* FacebookClient.swift */; };
 		D4E4957C93A4DA727F72A578 /* Pods_ios_trivia_game.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E46372423EA4DDD9D6F15AD0 /* Pods_ios_trivia_game.framework */; };
 /* End PBXBuildFile section */
 
@@ -81,13 +81,13 @@
 		A8B6EA301DD9A7AA00CB8699 /* User.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = User.swift; path = Models/User.swift; sourceTree = "<group>"; };
 		A8E1ED9E1DD5A03D00460AA5 /* JServiceClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = JServiceClient.swift; path = API/JServiceClient.swift; sourceTree = "<group>"; };
 		B2009CEC1DE5B70500CF0FB1 /* ScoredAnswer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ScoredAnswer.swift; path = Models/ScoredAnswer.swift; sourceTree = "<group>"; };
+		B236DB1A1DEEC65A0057D263 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		B29417041DE29A1300153E36 /* UserInGame.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserInGame.swift; path = Models/UserInGame.swift; sourceTree = "<group>"; };
 		B29417061DE29E3A00153E36 /* FirebaseClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FirebaseClient.swift; path = API/FirebaseClient.swift; sourceTree = "<group>"; };
 		B29417081DE2AD8100153E36 /* SelectFriendsTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SelectFriendsTableViewCell.swift; path = Views/SelectFriendsTableViewCell.swift; sourceTree = "<group>"; };
 		B29417091DE2AD8100153E36 /* HomeTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HomeTableViewCell.swift; path = Views/HomeTableViewCell.swift; sourceTree = "<group>"; };
 		B294170F1DE2DF8A00153E36 /* AnswerTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AnswerTableViewCell.swift; path = Views/AnswerTableViewCell.swift; sourceTree = "<group>"; };
 		B29BE1FC1DD7BB6B000DD684 /* Logger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Logger.swift; path = Logger/Logger.swift; sourceTree = "<group>"; };
-		B29E8C751DF0220600A1D48A /* FacebookClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FacebookClient.swift; path = API/FacebookClient.swift; sourceTree = "<group>"; };
 		B2AFE4581DEC20CB00999BD1 /* InviteViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = InviteViewController.swift; path = ViewControllers/InviteViewController.swift; sourceTree = "<group>"; };
 		B2AFE45A1DEC292C00999BD1 /* Invite.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Invite.swift; path = Models/Invite.swift; sourceTree = "<group>"; };
 		B2AFE45C1DEC2C1700999BD1 /* InviteTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = InviteTableViewCell.swift; path = Views/InviteTableViewCell.swift; sourceTree = "<group>"; };
@@ -96,7 +96,7 @@
 		B2DE69C61DEB79070038B860 /* FinalScore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FinalScore.swift; path = Models/FinalScore.swift; sourceTree = "<group>"; };
 		B2DE69C81DEB7E3E0038B860 /* FinalScoreTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FinalScoreTableViewCell.swift; path = Views/FinalScoreTableViewCell.swift; sourceTree = "<group>"; };
 		B2E11B191DE3F83C0008F8E0 /* Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utilities.swift; sourceTree = "<group>"; };
-		B2E6D38F1DF2957B001ABF12 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = "ios-trivia-game/Base.lproj/Main.storyboard"; sourceTree = "<group>"; };
+		B2EEF4F11DF2E23700BCA44D /* FacebookClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FacebookClient.swift; path = API/FacebookClient.swift; sourceTree = "<group>"; };
 		BBAA460E62FF4EB21F502AA3 /* Pods-ios-trivia-game.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios-trivia-game.release.xcconfig"; path = "Pods/Target Support Files/Pods-ios-trivia-game/Pods-ios-trivia-game.release.xcconfig"; sourceTree = "<group>"; };
 		E46372423EA4DDD9D6F15AD0 /* Pods_ios_trivia_game.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ios_trivia_game.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -172,8 +172,8 @@
 				B29BE1F41DD7B7D8000DD684 /* Models */,
 				A8E1ED9D1DD5A01100460AA5 /* API */,
 				A83ACC811DD2D14B00DAF701 /* AppDelegate.swift */,
+				B236DB191DEEC65A0057D263 /* Main.storyboard */,
 				A83ACC881DD2D14B00DAF701 /* Assets.xcassets */,
-				B2E6D38E1DF2957B001ABF12 /* Main.storyboard */,
 				A83ACC8A1DD2D14B00DAF701 /* LaunchScreen.storyboard */,
 				1A3686101DD84B5800CBEB41 /* GoogleService-Info.plist */,
 				A83ACC8D1DD2D14B00DAF701 /* Info.plist */,
@@ -186,8 +186,8 @@
 		A8B32B8E1DDBE6E7003A0B1C /* ViewControllers */ = {
 			isa = PBXGroup;
 			children = (
-				A8B32BB41DDC0379003A0B1C /* HomeViewController.swift */,
 				B2AFE4571DEC20B700999BD1 /* Invite */,
+				A8B32BB41DDC0379003A0B1C /* HomeViewController.swift */,
 				A8B32BA71DDC0129003A0B1C /* Game */,
 				A8B32B9E1DDC006F003A0B1C /* CreateGame */,
 				A8B32B9D1DDC0058003A0B1C /* Profile */,
@@ -231,9 +231,9 @@
 		A8E1ED9D1DD5A01100460AA5 /* API */ = {
 			isa = PBXGroup;
 			children = (
+				B2EEF4F11DF2E23700BCA44D /* FacebookClient.swift */,
 				A8E1ED9E1DD5A03D00460AA5 /* JServiceClient.swift */,
 				B29417061DE29E3A00153E36 /* FirebaseClient.swift */,
-				B29E8C751DF0220600A1D48A /* FacebookClient.swift */,
 			);
 			name = API;
 			sourceTree = "<group>";
@@ -349,7 +349,7 @@
 				A83ACC8C1DD2D14B00DAF701 /* LaunchScreen.storyboard in Resources */,
 				1A3686111DD84B5800CBEB41 /* GoogleService-Info.plist in Resources */,
 				A83ACC891DD2D14B00DAF701 /* Assets.xcassets in Resources */,
-				B2E6D3901DF2957B001ABF12 /* Main.storyboard in Resources */,
+				B236DB1B1DEEC65A0057D263 /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -419,7 +419,6 @@
 				B29BE1FD1DD7BB6B000DD684 /* Logger.swift in Sources */,
 				A8B32BB51DDC0379003A0B1C /* HomeViewController.swift in Sources */,
 				A8B32B961DDBFF4A003A0B1C /* CameraViewController.swift in Sources */,
-				B29E8C761DF0220600A1D48A /* FacebookClient.swift in Sources */,
 				A83ACC821DD2D14B00DAF701 /* AppDelegate.swift in Sources */,
 				A8B32BA41DDC00D8003A0B1C /* GameOptionsViewController.swift in Sources */,
 				1A805B6D1DD996F900A70691 /* TriviaCategory.swift in Sources */,
@@ -428,6 +427,7 @@
 				A8B32B941DDBEA7E003A0B1C /* ProfileViewController.swift in Sources */,
 				B29417051DE29A1300153E36 /* UserInGame.swift in Sources */,
 				B2DE69C91DEB7E3E0038B860 /* FinalScoreTableViewCell.swift in Sources */,
+				B2EEF4F21DF2E23700BCA44D /* FacebookClient.swift in Sources */,
 				B29417101DE2DF8A00153E36 /* AnswerTableViewCell.swift in Sources */,
 				B2DE69C71DEB79070038B860 /* FinalScore.swift in Sources */,
 				B294170B1DE2AD8100153E36 /* HomeTableViewCell.swift in Sources */,
@@ -459,13 +459,12 @@
 			name = LaunchScreen.storyboard;
 			sourceTree = "<group>";
 		};
-		B2E6D38E1DF2957B001ABF12 /* Main.storyboard */ = {
+		B236DB191DEEC65A0057D263 /* Main.storyboard */ = {
 			isa = PBXVariantGroup;
 			children = (
-				B2E6D38F1DF2957B001ABF12 /* Base */,
+				B236DB1A1DEEC65A0057D263 /* Base */,
 			);
 			name = Main.storyboard;
-			path = ..;
 			sourceTree = "<group>";
 		};
 /* End PBXVariantGroup section */

--- a/ios-trivia-game.xcodeproj/project.pbxproj
+++ b/ios-trivia-game.xcodeproj/project.pbxproj
@@ -32,13 +32,13 @@
 		A8E541571DD9A9EB002D6AA4 /* JServiceClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E1ED9E1DD5A03D00460AA5 /* JServiceClient.swift */; };
 		A8E541581DD9A9EB002D6AA4 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A36860A1DD83CCC00CBEB41 /* Constants.swift */; };
 		B2009CED1DE5B70500CF0FB1 /* ScoredAnswer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2009CEC1DE5B70500CF0FB1 /* ScoredAnswer.swift */; };
-		B236DB1B1DEEC65A0057D263 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B236DB191DEEC65A0057D263 /* Main.storyboard */; };
 		B29417051DE29A1300153E36 /* UserInGame.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29417041DE29A1300153E36 /* UserInGame.swift */; };
 		B29417071DE29E3A00153E36 /* FirebaseClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29417061DE29E3A00153E36 /* FirebaseClient.swift */; };
 		B294170A1DE2AD8100153E36 /* SelectFriendsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29417081DE2AD8100153E36 /* SelectFriendsTableViewCell.swift */; };
 		B294170B1DE2AD8100153E36 /* HomeTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29417091DE2AD8100153E36 /* HomeTableViewCell.swift */; };
 		B29417101DE2DF8A00153E36 /* AnswerTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B294170F1DE2DF8A00153E36 /* AnswerTableViewCell.swift */; };
 		B29BE1FD1DD7BB6B000DD684 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29BE1FC1DD7BB6B000DD684 /* Logger.swift */; };
+		B29E8C761DF0220600A1D48A /* FacebookClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = B29E8C751DF0220600A1D48A /* FacebookClient.swift */; };
 		B2AFE4591DEC20CB00999BD1 /* InviteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2AFE4581DEC20CB00999BD1 /* InviteViewController.swift */; };
 		B2AFE45B1DEC292C00999BD1 /* Invite.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2AFE45A1DEC292C00999BD1 /* Invite.swift */; };
 		B2AFE45D1DEC2C1700999BD1 /* InviteTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2AFE45C1DEC2C1700999BD1 /* InviteTableViewCell.swift */; };
@@ -47,6 +47,7 @@
 		B2DE69C71DEB79070038B860 /* FinalScore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2DE69C61DEB79070038B860 /* FinalScore.swift */; };
 		B2DE69C91DEB7E3E0038B860 /* FinalScoreTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2DE69C81DEB7E3E0038B860 /* FinalScoreTableViewCell.swift */; };
 		B2E11B1A1DE3F83C0008F8E0 /* Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2E11B191DE3F83C0008F8E0 /* Utilities.swift */; };
+		B2E6D3901DF2957B001ABF12 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B2E6D38E1DF2957B001ABF12 /* Main.storyboard */; };
 		D4E4957C93A4DA727F72A578 /* Pods_ios_trivia_game.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E46372423EA4DDD9D6F15AD0 /* Pods_ios_trivia_game.framework */; };
 /* End PBXBuildFile section */
 
@@ -80,13 +81,13 @@
 		A8B6EA301DD9A7AA00CB8699 /* User.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = User.swift; path = Models/User.swift; sourceTree = "<group>"; };
 		A8E1ED9E1DD5A03D00460AA5 /* JServiceClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = JServiceClient.swift; path = API/JServiceClient.swift; sourceTree = "<group>"; };
 		B2009CEC1DE5B70500CF0FB1 /* ScoredAnswer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ScoredAnswer.swift; path = Models/ScoredAnswer.swift; sourceTree = "<group>"; };
-		B236DB1A1DEEC65A0057D263 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		B29417041DE29A1300153E36 /* UserInGame.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UserInGame.swift; path = Models/UserInGame.swift; sourceTree = "<group>"; };
 		B29417061DE29E3A00153E36 /* FirebaseClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FirebaseClient.swift; path = API/FirebaseClient.swift; sourceTree = "<group>"; };
 		B29417081DE2AD8100153E36 /* SelectFriendsTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SelectFriendsTableViewCell.swift; path = Views/SelectFriendsTableViewCell.swift; sourceTree = "<group>"; };
 		B29417091DE2AD8100153E36 /* HomeTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = HomeTableViewCell.swift; path = Views/HomeTableViewCell.swift; sourceTree = "<group>"; };
 		B294170F1DE2DF8A00153E36 /* AnswerTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AnswerTableViewCell.swift; path = Views/AnswerTableViewCell.swift; sourceTree = "<group>"; };
 		B29BE1FC1DD7BB6B000DD684 /* Logger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Logger.swift; path = Logger/Logger.swift; sourceTree = "<group>"; };
+		B29E8C751DF0220600A1D48A /* FacebookClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FacebookClient.swift; path = API/FacebookClient.swift; sourceTree = "<group>"; };
 		B2AFE4581DEC20CB00999BD1 /* InviteViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = InviteViewController.swift; path = ViewControllers/InviteViewController.swift; sourceTree = "<group>"; };
 		B2AFE45A1DEC292C00999BD1 /* Invite.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Invite.swift; path = Models/Invite.swift; sourceTree = "<group>"; };
 		B2AFE45C1DEC2C1700999BD1 /* InviteTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = InviteTableViewCell.swift; path = Views/InviteTableViewCell.swift; sourceTree = "<group>"; };
@@ -95,6 +96,7 @@
 		B2DE69C61DEB79070038B860 /* FinalScore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FinalScore.swift; path = Models/FinalScore.swift; sourceTree = "<group>"; };
 		B2DE69C81DEB7E3E0038B860 /* FinalScoreTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FinalScoreTableViewCell.swift; path = Views/FinalScoreTableViewCell.swift; sourceTree = "<group>"; };
 		B2E11B191DE3F83C0008F8E0 /* Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utilities.swift; sourceTree = "<group>"; };
+		B2E6D38F1DF2957B001ABF12 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = "ios-trivia-game/Base.lproj/Main.storyboard"; sourceTree = "<group>"; };
 		BBAA460E62FF4EB21F502AA3 /* Pods-ios-trivia-game.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ios-trivia-game.release.xcconfig"; path = "Pods/Target Support Files/Pods-ios-trivia-game/Pods-ios-trivia-game.release.xcconfig"; sourceTree = "<group>"; };
 		E46372423EA4DDD9D6F15AD0 /* Pods_ios_trivia_game.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ios_trivia_game.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -170,8 +172,8 @@
 				B29BE1F41DD7B7D8000DD684 /* Models */,
 				A8E1ED9D1DD5A01100460AA5 /* API */,
 				A83ACC811DD2D14B00DAF701 /* AppDelegate.swift */,
-				B236DB191DEEC65A0057D263 /* Main.storyboard */,
 				A83ACC881DD2D14B00DAF701 /* Assets.xcassets */,
+				B2E6D38E1DF2957B001ABF12 /* Main.storyboard */,
 				A83ACC8A1DD2D14B00DAF701 /* LaunchScreen.storyboard */,
 				1A3686101DD84B5800CBEB41 /* GoogleService-Info.plist */,
 				A83ACC8D1DD2D14B00DAF701 /* Info.plist */,
@@ -231,6 +233,7 @@
 			children = (
 				A8E1ED9E1DD5A03D00460AA5 /* JServiceClient.swift */,
 				B29417061DE29E3A00153E36 /* FirebaseClient.swift */,
+				B29E8C751DF0220600A1D48A /* FacebookClient.swift */,
 			);
 			name = API;
 			sourceTree = "<group>";
@@ -346,7 +349,7 @@
 				A83ACC8C1DD2D14B00DAF701 /* LaunchScreen.storyboard in Resources */,
 				1A3686111DD84B5800CBEB41 /* GoogleService-Info.plist in Resources */,
 				A83ACC891DD2D14B00DAF701 /* Assets.xcassets in Resources */,
-				B236DB1B1DEEC65A0057D263 /* Main.storyboard in Resources */,
+				B2E6D3901DF2957B001ABF12 /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -416,6 +419,7 @@
 				B29BE1FD1DD7BB6B000DD684 /* Logger.swift in Sources */,
 				A8B32BB51DDC0379003A0B1C /* HomeViewController.swift in Sources */,
 				A8B32B961DDBFF4A003A0B1C /* CameraViewController.swift in Sources */,
+				B29E8C761DF0220600A1D48A /* FacebookClient.swift in Sources */,
 				A83ACC821DD2D14B00DAF701 /* AppDelegate.swift in Sources */,
 				A8B32BA41DDC00D8003A0B1C /* GameOptionsViewController.swift in Sources */,
 				1A805B6D1DD996F900A70691 /* TriviaCategory.swift in Sources */,
@@ -455,12 +459,13 @@
 			name = LaunchScreen.storyboard;
 			sourceTree = "<group>";
 		};
-		B236DB191DEEC65A0057D263 /* Main.storyboard */ = {
+		B2E6D38E1DF2957B001ABF12 /* Main.storyboard */ = {
 			isa = PBXVariantGroup;
 			children = (
-				B236DB1A1DEEC65A0057D263 /* Base */,
+				B2E6D38F1DF2957B001ABF12 /* Base */,
 			);
 			name = Main.storyboard;
+			path = ..;
 			sourceTree = "<group>";
 		};
 /* End PBXVariantGroup section */

--- a/ios-trivia-game/API/FacebookClient.swift
+++ b/ios-trivia-game/API/FacebookClient.swift
@@ -1,0 +1,39 @@
+//
+//  FacebookClient.swift
+//  ios-trivia-game
+//
+//  Created by Savio Tsui on 12/1/16.
+//  Copyright © 2016 Team NZS. All rights reserved.
+//
+
+import Foundation
+import FBSDKLoginKit
+
+class FacebookClient {
+    
+    static let instance = FacebookClient()
+    
+    private init() {}
+    
+    // gets current user taggable friends
+    func getCurrentUserTaggableFriends(parameters: [String]? = ["id", "first_name", "last_name", "middle_name", "name", "email", "picture"], complete: FBSDKCoreKit.FBSDKGraphRequestHandler!) -> FBSDKGraphRequestConnection! {
+        let paramString = parameters!.joined(separator: ", ")
+        let request = FBSDKGraphRequest(graphPath: "me/taggable_friends", parameters: ["fields": paramString])
+        return request?.start(completionHandler: complete)
+    }
+    
+    // gets current user registered friends
+    func getCurrentUserFriends(parameters: [String]? = ["id", "first_name", "last_name", "middle_name", "name", "email", "picture"], complete: FBSDKCoreKit.FBSDKGraphRequestHandler!) -> FBSDKGraphRequestConnection! {
+        let paramString = parameters!.joined(separator: ", ")
+        let request = FBSDKGraphRequest(graphPath: "me/friends", parameters: ["fields": paramString])
+        return request?.start(completionHandler: complete)
+    }
+    
+    // gets current user data
+    func getCurrentUserData(parameters: [String]? = ["id", "first_name", "last_name", "middle_name", "name", "email", "picture"], complete: FBSDKCoreKit.FBSDKGraphRequestHandler!) -> FBSDKGraphRequestConnection! {
+        let paramString = parameters!.joined(separator: ", ")
+        let request = FBSDKGraphRequest(graphPath: "me", parameters: ["fields": paramString])
+        return request?.start(completionHandler: complete)
+    }
+
+}

--- a/ios-trivia-game/AppDelegate.swift
+++ b/ios-trivia-game/AppDelegate.swift
@@ -9,7 +9,6 @@
 import UIKit
 import Firebase
 import FacebookCore
-import FBSDKLoginKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {

--- a/ios-trivia-game/Base.lproj/Main.storyboard
+++ b/ios-trivia-game/Base.lproj/Main.storyboard
@@ -352,11 +352,11 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="com.iostriviagame.selecfriendstableviewcell" rowHeight="64" id="9Sz-xb-sx7" customClass="SelectFriendsTableViewCell" customModule="ios_trivia_game" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="com.iostriviagame.selectfriendstableviewcell" rowHeight="64" id="9Sz-xb-sx7" customClass="SelectFriendsTableViewCell" customModule="ios_trivia_game" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="28" width="375" height="64"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="9Sz-xb-sx7" id="5e0-Q8-5WS">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="63"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="63.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Full Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YCF-2C-FYl">
@@ -419,7 +419,6 @@
                         <barButtonItem key="leftBarButtonItem" title="Back" id="7oK-RW-j68">
                             <connections>
                                 <action selector="onBackClicked:" destination="ekw-Vi-1cd" id="bRU-FY-WAj"/>
-                                <segue destination="X9v-Hd-GYg" kind="presentation" id="9L0-hO-pBe"/>
                             </connections>
                         </barButtonItem>
                         <barButtonItem key="rightBarButtonItem" title="Game Options" id="xxQ-Jt-ZgS">
@@ -479,7 +478,6 @@
                         <barButtonItem key="leftBarButtonItem" title="Back" id="lWX-YV-zGc">
                             <connections>
                                 <action selector="onBackClicked:" destination="i5F-5m-G0r" id="mc0-vI-JeP"/>
-                                <segue destination="5bb-5X-bDg" kind="presentation" id="vfX-BH-Apx"/>
                             </connections>
                         </barButtonItem>
                         <barButtonItem key="rightBarButtonItem" title="Start Game" id="UPb-KT-vZq">
@@ -594,7 +592,7 @@
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="UpN-wj-CWf" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="xzj-M9-BFF">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="xzj-M9-BFF">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -630,11 +628,11 @@
         <!--Create-->
         <scene sceneID="YKS-GH-nq8">
             <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="X9v-Hd-GYg" sceneMemberID="viewController">
+                <navigationController storyboardIdentifier="com.iostriviagame.creategamenavigationviewcontroller" automaticallyAdjustsScrollViewInsets="NO" id="X9v-Hd-GYg" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" title="Create" id="3PX-mo-79e"/>
                     <toolbarItems/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="PfN-jp-rFR">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="PfN-jp-rFR">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -706,7 +704,7 @@
                                         <rect key="frame" x="0.0" y="28" width="311" height="102"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="rUh-fW-Bmr" id="r3R-zq-vxP">
-                                            <rect key="frame" x="0.0" y="0.0" width="311" height="101"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="311" height="101.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Answer" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NKo-Tc-GgM">
@@ -810,7 +808,7 @@
                                         <rect key="frame" x="0.0" y="28" width="311" height="61"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="L7y-rf-jUI" id="tMU-0V-Ruk">
-                                            <rect key="frame" x="0.0" y="0.0" width="311" height="60"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="311" height="60.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="player" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fA5-AY-R6c">
@@ -896,7 +894,7 @@
                                         <rect key="frame" x="0.0" y="28" width="375" height="137"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="sZu-Nk-Kd0" id="3wO-7d-PgA">
-                                            <rect key="frame" x="0.0" y="0.0" width="342" height="136"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="342" height="136.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Game Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n96-rY-Pc3">
@@ -970,7 +968,7 @@
                     <tabBarItem key="tabBarItem" title="Home" id="zNZ-Aj-jh8"/>
                     <toolbarItems/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="nFV-wb-q5N">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="nFV-wb-q5N">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -986,9 +984,9 @@
         <!--Navigation Controller-->
         <scene sceneID="IUI-Wv-InZ">
             <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="5bb-5X-bDg" sceneMemberID="viewController">
+                <navigationController storyboardIdentifier="com.iostriviagame.selectfriendsnavigationviewcontroller" automaticallyAdjustsScrollViewInsets="NO" useStoryboardIdentifierAsRestorationIdentifier="YES" id="5bb-5X-bDg" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="dcG-GP-j2w">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="dcG-GP-j2w">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -1004,9 +1002,9 @@
         <!--Navigation Controller-->
         <scene sceneID="cff-DD-e6O">
             <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="RHu-CO-bv6" sceneMemberID="viewController">
+                <navigationController storyboardIdentifier="com.iostriviagame.gameoptionsnavigationviewcontroller" automaticallyAdjustsScrollViewInsets="NO" useStoryboardIdentifierAsRestorationIdentifier="YES" id="RHu-CO-bv6" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="dFq-ex-OQM">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="dFq-ex-OQM">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -1024,7 +1022,7 @@
             <objects>
                 <navigationController storyboardIdentifier="com.iostriviagame.countdownnavigationviewcontroller" automaticallyAdjustsScrollViewInsets="NO" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Dzo-UG-g8U" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="Pu8-hs-FhN">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="Pu8-hs-FhN">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -1042,7 +1040,7 @@
             <objects>
                 <navigationController storyboardIdentifier="com.iostriviagame.questionnavigationviewcontroller" automaticallyAdjustsScrollViewInsets="NO" useStoryboardIdentifierAsRestorationIdentifier="YES" id="kGA-Pt-17m" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="wvZ-YW-tHI">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="wvZ-YW-tHI">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -1060,7 +1058,7 @@
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="1wV-hE-H6O" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="MXY-O0-zxP">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="MXY-O0-zxP">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -1078,7 +1076,7 @@
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="OYM-1H-SDT" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="ECi-Sp-Mrl">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="ECi-Sp-Mrl">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -1123,7 +1121,7 @@
                                         <rect key="frame" x="0.0" y="28" width="311" height="61"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="PHZ-fT-MIe" id="FtN-hM-u1W">
-                                            <rect key="frame" x="0.0" y="0.0" width="311" height="60"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="311" height="60.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="player" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Utv-Cy-l1S">
@@ -1199,7 +1197,7 @@
             <objects>
                 <navigationController storyboardIdentifier="com.iostriviagame.finalscorenavigationviewcontroller" automaticallyAdjustsScrollViewInsets="NO" useStoryboardIdentifierAsRestorationIdentifier="YES" id="xWC-Yo-6sB" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="6s3-Jb-LfK">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="6s3-Jb-LfK">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -1214,7 +1212,6 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="9L0-hO-pBe"/>
-        <segue reference="9qG-Ei-58r"/>
+        <segue reference="1Mc-Ha-1gq"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/ios-trivia-game/Constants.swift
+++ b/ios-trivia-game/Constants.swift
@@ -27,13 +27,17 @@ class Constants {
     static let QUESTION_NAVIGATION_VIEW_CONTROLLER = "com.iostriviagame.questionnavigationviewcontroller"
     static let FINAL_SCORE_NAVIGATION_VIEW_CONTROLLER = "com.iostriviagame.finalscorenavigationviewcontroller"
     static let ANSWER_TABLE_VIEW_CELL = "com.iostriviagame.answertableviewcell"
+    static let SELECT_FRIENDS_NAVIGATION_VIEW_CONTROLLER = "com.iostriviagame.selectfriendsnavigationviewcontroller"
     static let SELECT_FRIENDS_VIEW_CONTROLLER = "com.iostriviagame.selectfriendsviewcontroller"
+    static let GAME_OPTIONS_NAVIGATION_VIEW_CONTROLLER = "com.iostriviagame.gameoptionsnavigationviewcontroller"
     static let GAME_OPTIONS_VIEW_CONTROLLER = "com.iostriviagame.gameoptionsviewcontroller"
     static let COUNTDOWN_NAVIGATION_VIEW_CONTROLLER = "com.iostriviagame.countdownnavigationviewcontroller"
     static let COUNTDOWN_GAME_VIEW_CONTROLLER = "com.iostriviagame.countdowngameviewcontroller"
     static let RESULT_TABLE_VIEW_CELL = "com.iostriviagame.resulttableviewcell"
     static let FINAL_SCORE_TABLE_VIEW_CELL = "com.iostriviagame.finalscoretableviewcell"
     static let INVITE_TABLE_VIEW_CELL = "com.iostriviagame.invitetableviewcell"
+    static let SELECT_FRIENDS_TABLE_VIEW_CELL = "com.iostriviagame.selectfriendstableviewcell"
+    static let CREATE_GAME_NAVIGATION_VIEW_CONTROLLER = "com.iostriviagame.creategamenavigationviewcontroller"
     
     static let GAME_START_COUNTDOWN = 30
 }

--- a/ios-trivia-game/ViewControllers/FinalScoreViewController.swift
+++ b/ios-trivia-game/ViewControllers/FinalScoreViewController.swift
@@ -54,7 +54,7 @@ class FinalScoreViewController: UIViewController {
                                 
                                 let finalScore = FinalScore(roomId: self.roomId, user: user, score: playerGameScore)
                                 
-                                if (finalScore.user.uid == User.currentUser?.uid) {
+                                if (finalScore.user.uid! == User.currentUser?.uid!) {
                                     self.currentUserFinalScore = finalScore
                                 }
                                 

--- a/ios-trivia-game/ViewControllers/HomeViewController.swift
+++ b/ios-trivia-game/ViewControllers/HomeViewController.swift
@@ -96,9 +96,28 @@ extension HomeViewController: UITableViewDelegate, UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        // prepare for segue
-        print ("Selected \(indexPath.row)")
-        print ("Segue should happen here, perhaps ask the user if he really wants to join?")
+        let selectedGameRoom = self.roomsToShow![indexPath.row]
+        
+        // Access the image or the cell at this index path
+        FirebaseClient.instance.joinGame(roomId: selectedGameRoom.id, complete: { (remainingCountdownTime) in
+            
+            // transition to countdown
+            let storyboard = UIStoryboard(name: "Main", bundle: nil)
+            let destination = storyboard.instantiateViewController(withIdentifier: Constants.COUNTDOWN_NAVIGATION_VIEW_CONTROLLER)
+            let countdownNavigationController = destination as! UINavigationController
+            let countdownGameViewController = countdownNavigationController.topViewController as! CountdownGameViewController
+            
+            countdownGameViewController.timerCount = remainingCountdownTime
+            countdownGameViewController.roomId = selectedGameRoom.id!
+            
+            self.present(destination, animated: true, completion: nil)
+        }, fail: {
+            // do not transition, throw up a popup
+            let alertController = UIAlertController(title: "Warning", message:
+                "Unable to join this game. Please try another.", preferredStyle: UIAlertControllerStyle.alert)
+            alertController.addAction(UIAlertAction(title: "Dismiss", style: UIAlertActionStyle.default,handler: nil))
+            self.present(alertController, animated: true, completion: nil)
+        })
     }
 }
 

--- a/ios-trivia-game/ViewControllers/InviteViewController.swift
+++ b/ios-trivia-game/ViewControllers/InviteViewController.swift
@@ -69,10 +69,10 @@ class InviteViewController: UIViewController {
                     let invite = Invite(dictionary: value as! NSDictionary)
                     self.invites.append(invite)
                 }
-                
-                self.inviteTableView.reloadData()
-                self.refreshControl.endRefreshing()
             }
+            
+            self.inviteTableView.reloadData()
+            self.refreshControl.endRefreshing()
         }, onError: { (error) in })
     }
 }

--- a/ios-trivia-game/ViewControllers/ProfileViewController.swift
+++ b/ios-trivia-game/ViewControllers/ProfileViewController.swift
@@ -49,7 +49,7 @@ class ProfileViewController: UIViewController {
         self.profileImageView.setImageWith(URL(string: self.user.photoUrl!)!)
         self.profileImageView.layer.cornerRadius = self.profileImageView.frame.size.width / 2;
         
-        self.nicknameLabel.text = "somenickname"
+        self.nicknameLabel.text = self.user.nickname!
         self.nameLabel.text = self.user.name!
         self.emailLabel.text = self.user.email!
     }

--- a/ios-trivia-game/ViewControllers/SelectFriendsViewController.swift
+++ b/ios-trivia-game/ViewControllers/SelectFriendsViewController.swift
@@ -7,8 +7,6 @@
 //
 
 import UIKit
-import FacebookCore
-import FBSDKLoginKit
 
 class SelectFriendsViewController: UIViewController {
     
@@ -20,11 +18,16 @@ class SelectFriendsViewController: UIViewController {
     var isPublic: Bool?
     var nameOfGameroom: String?
     
-    var friends = [Friend]()
-    var filteredFriendsList = [Friend]()
+    fileprivate let REGISTERED = 0
+    fileprivate let UNREGISTERED = 1
+    fileprivate let friendCategories = ["Registered", "Unregistered"]
+    var friends: [[Friend]] = [[], []]
+    var filteredFriendsList: [[Friend]] = [[], []]
     var currentSelectedCount:Int = 1
     var isFromUserEvent:Bool = true
     var selectedFriends = Set<String>()
+    
+    internal let mainStoryboard = UIStoryboard(name: "Main", bundle: nil)
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -41,7 +44,6 @@ class SelectFriendsViewController: UIViewController {
     }
     
     @IBAction func onBackClicked(_ sender: Any) {
-        dismiss(animated: true, completion: nil)
         _ = self.navigationController?.popViewController(animated: true)
     }
     
@@ -58,23 +60,31 @@ class SelectFriendsViewController: UIViewController {
     }
     
     func loadFriendsList() {
-        let params = ["fields": "id, first_name, last_name, middle_name, name, email, picture"]
-        let request = FBSDKGraphRequest(graphPath: "me/taggable_friends", parameters: params)
-        _ = request?.start(completionHandler: { (_, result: Any?, error: Error?) in
+        _ = FacebookClient.instance.getCurrentUserTaggableFriends(complete: { (_, result: Any?, error: Error?) in
             if error != nil {
                 let errorMessage = error?.localizedDescription
                 print("error: \(errorMessage)")
             }
             let data = result as! NSDictionary
             let dictionaries = data["data"] as! [NSDictionary]
-            self.friends = Friend.FriendsWithArray(dictionaries: dictionaries)
+            self.friends[self.UNREGISTERED] = Friend.FriendsWithArray(dictionaries: dictionaries)
+            self.tableView.reloadData()
+        })
+        
+        _ = FacebookClient.instance.getCurrentUserFriends(complete: { (_, result: Any?, error: Error?) in
+            if error != nil {
+                let errorMessage = error?.localizedDescription
+                print("error: \(errorMessage)")
+            }
+            let data = result as! NSDictionary
+            let dictionaries = data["data"] as! [NSDictionary]
+            self.friends[self.REGISTERED] = Friend.FriendsWithArray(dictionaries: dictionaries)
             self.tableView.reloadData()
         })
     }
 
     @IBAction func onGameOptionsClicked(_ sender: Any) {
-        let storyboard = UIStoryboard(name: "Main", bundle: nil)
-        let gameOptionsViewController = storyboard.instantiateViewController(withIdentifier: Constants.GAME_OPTIONS_VIEW_CONTROLLER) as! GameOptionsViewController
+        let gameOptionsViewController = self.mainStoryboard.instantiateViewController(withIdentifier: Constants.GAME_OPTIONS_VIEW_CONTROLLER) as! GameOptionsViewController
         gameOptionsViewController.numOfPlayers = self.numOfPlayers
         gameOptionsViewController.isPublic = self.isPublic
         gameOptionsViewController.nameOfGameroom = self.nameOfGameroom
@@ -83,11 +93,15 @@ class SelectFriendsViewController: UIViewController {
     }
     
     func updateListWithKeyword(keyword: String) {
-        filteredFriendsList.removeAll()
-        for friend in friends {
-            if (friend.name?.lowercased().range(of: keyword.lowercased())) != nil {
-                filteredFriendsList.append(friend)
+        var index = 0
+        for friendList in friends {
+            filteredFriendsList[index].removeAll()
+            for friend in friendList {
+                if (friend.name?.lowercased().range(of: keyword.lowercased())) != nil {
+                    filteredFriendsList[index].append(friend)
+                }
             }
+            index = index + 1
         }
         tableView.reloadData()
     }
@@ -125,26 +139,33 @@ extension SelectFriendsViewController: UISearchBarDelegate {
 }
 
 extension SelectFriendsViewController: UITableViewDataSource, UITableViewDelegate {
-    
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         if self.searchBar.text != nil && (self.searchBar.text?.characters.count)! > 0 {
-            return self.filteredFriendsList.count
+            return self.filteredFriendsList[section].count
         } else {
-            return self.friends.count
+            return self.friends[section].count
         }
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "com.iostriviagame.selecfriendstableviewcell", for: indexPath) as! SelectFriendsTableViewCell
+        let cell = tableView.dequeueReusableCell(withIdentifier: Constants.SELECT_FRIENDS_TABLE_VIEW_CELL, for: indexPath) as! SelectFriendsTableViewCell
         if self.searchBar.text != nil && (self.searchBar.text?.characters.count)! > 0 {
-            cell.friend = self.filteredFriendsList[indexPath.row]
-            cell.onSwitch.isOn = self.filteredFriendsList[indexPath.row].isSelected ?? false
+            cell.friend = self.filteredFriendsList[indexPath.section][indexPath.row]
+            cell.onSwitch.isOn = self.filteredFriendsList[indexPath.section][indexPath.row].isSelected ?? false
         } else {
-            cell.friend = self.friends[indexPath.row]
-            cell.onSwitch.isOn = self.friends[indexPath.row].isSelected ?? false
+            cell.friend = self.friends[indexPath.section][indexPath.row]
+            cell.onSwitch.isOn = self.friends[indexPath.section][indexPath.row].isSelected ?? false
         }
         cell.delegate = self
         return cell
+    }
+    
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return self.friends.count
+    }
+    
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return friendCategories[section]
     }
 }
 
@@ -152,6 +173,8 @@ extension SelectFriendsViewController: SelectFriendsTableViewCellDelegate {
     
     func selectFriendsTableViewCell(selectFriendsTableViewCell: SelectFriendsTableViewCell, didChangeValue value: Bool) {
         let indexPath = tableView.indexPath(for: selectFriendsTableViewCell)!
+        
+        selectFriendsTableViewCell.selectionStyle = .none
         
         if value && currentSelectedCount >= numOfPlayers! {
             let alertController = UIAlertController(title: "Warning", message:
@@ -167,9 +190,9 @@ extension SelectFriendsViewController: SelectFriendsTableViewCellDelegate {
         
             if isFromUserEvent {
                 if self.searchBar.text != nil && (self.searchBar.text?.characters.count)! > 0 {
-                    self.filteredFriendsList[indexPath.row].isSelected = value
+                    self.filteredFriendsList[indexPath.section][indexPath.row].isSelected = value
                 } else {
-                    self.friends[indexPath.row].isSelected = value
+                    self.friends[indexPath.section][indexPath.row].isSelected = value
                 }
                 if value {
                     currentSelectedCount += 1
@@ -180,9 +203,9 @@ extension SelectFriendsViewController: SelectFriendsTableViewCellDelegate {
                 }
         
                 if self.searchBar.text != nil && (self.searchBar.text?.characters.count)! > 0 {
-                    updateSelectedFriendsLabel(isSelected: value, name: filteredFriendsList[indexPath.row].name!)
+                    updateSelectedFriendsLabel(isSelected: value, name: filteredFriendsList[indexPath.section][indexPath.row].name!)
                 } else {
-                    updateSelectedFriendsLabel(isSelected: value, name: friends[indexPath.row].name!)
+                    updateSelectedFriendsLabel(isSelected: value, name: friends[indexPath.section][indexPath.row].name!)
                 }
             } else {
                 isFromUserEvent = true


### PR DESCRIPTION
1. Created FacebookClient
2. FirebaseClient
- createUser
- updateUser
- createInviteFor
3. Updates to User Entity
4. SelectFriendsViewController now displays two types of friends to match "taggable_friends", and "friends" from facebook api.  Back story is, friends are people that have installed and authorized our app to be used.  taggable_friends is theoretically a set of people we can post to their wall to join a game.
- "friends" returns a persistent id which allows us to id and save a user to the user table
- "taggable_friends" is a randomized hashcode.  we cant save these to our user table.  At this time, we do nothing but it is theoretically possible that we can post to their wall to join a game.
5. Join Game from main view
6. Fixing our back buttons so they don't crash out app

![invitesandfriends](https://cloud.githubusercontent.com/assets/6089079/20858934/0344a2a6-b905-11e6-84c8-ca5f2ea3f874.gif)
<img width="655" alt="screen shot 2016-12-03 at 3 02 30 am" src="https://cloud.githubusercontent.com/assets/6089079/20858932/f6c582f2-b904-11e6-89cc-b51c509b2976.png">
<img width="390" alt="screen shot 2016-12-03 at 3 02 10 am" src="https://cloud.githubusercontent.com/assets/6089079/20858931/f6c3c2fa-b904-11e6-9596-96d6454e0d18.png">
